### PR TITLE
Refactor exposed port identification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN yum -y install \
     # Docker daemon won't start without `iptables` installed
     iptables-services \
     # Used for a variety of simple tests for port forwarding/publishing
-    nmap-ncat \
+    nmap-ncat net-tools \
     # Allow `dock-user` to escalate privileges if necessary
     sudo \
     # Allow us to run using OverlayFS file system

--- a/bin/dock
+++ b/bin/dock
@@ -693,7 +693,12 @@ destroy_container() {
 }
 
 port_taken_on_localhost() {
-  echo | nc -w 1 localhost $1 >/dev/null 2>&1
+  if osx; then
+    # show -a(ll sockets) and -n(umeric addresses)
+    echo | netstat -a -n 2>/dev/null | grep $1 >/dev/null 2>&1
+  else
+    echo | netstat --numeric --listening 2>/dev/null | grep $1 >/dev/null 2>&1
+  fi
 }
 
 process_exposed_ports() {


### PR DESCRIPTION
The previous mechanism for identifying exposed ports on
host machines was flakey and not really an ideal/efficient
means of identifying exposed ports (i.e attempting to connect
to port with a 1 second timeout). This change modifies the method
to make use of netstat and varies the usage based on the host
OS appropriately.