### PR TITLE
Only record compose label for project with docker-compose file

### DIFF
--- a/bin/dock
+++ b/bin/dock
@@ -498,7 +498,13 @@ extend_container() {
 
   # add Dock environment construction labels
   label "dock.${project}" "$(pwd)/.dock"
-  label "compose.${project}" "$(pwd)/docker-compose.yml"
+  # Projects do not necessarily need to supply a docker-compose file so only add a
+  # label if the file exists
+  if [ -e "$(pwd)/docker-compose.yml" ]; then
+    label "compose.${project}" "$(pwd)/${default_compose_file}"
+  else
+    info "Unable to locate a $default_compose_file file for ${project}."
+  fi
 
   # proceed to launch extended dock container...
   # TODO: refactor below common setup (i.e. build of docker run args) to remove code

--- a/test/options/extend.bats
+++ b/test/options/extend.bats
@@ -37,6 +37,26 @@ EOF
   echo "$labels" | grep dock.my-project
 }
 
+@test "compose configuration label is not added to Dock container if compose file does not exist" {
+  file Dockerfile <<-EOF
+FROM alpine:latest
+EOF
+
+  file .dock <<-EOF
+dockerfile Dockerfile
+default_command sh
+EOF
+
+  run dock -e test
+
+  [ "$status" -eq 0 ]
+  labels="$(get_labels test)"
+  # ensure compose construction label for project is NOT set
+  [[ "${lines[1]}" =~ "Unable to locate a docker-compose.yml file" ]]
+  echo "$labels" | grep -v compose.my-project
+  echo "$labels" | grep dock.my-project
+}
+
 @test "workspace dir is set as repo root of project during extension" {
   file Dockerfile <<-EOF
 FROM alpine:latest


### PR DESCRIPTION
docker-compose files are not required for a project to be targeted
during dock extension so we should check for file existence and only
add a container construction label if the file exists.