### PR TITLE
Set privileged container and pull_latest flag defaults to true

### DIFF
--- a/bin/dock
+++ b/bin/dock
@@ -486,7 +486,6 @@ extend_container() {
   fi
 
   notice "Extending Dock: $1..."
-
   # Set image and container names accordingly
   container_name "$(convert_to_valid_container_name $1)"
   extended_image="$container_name:dock"
@@ -667,7 +666,7 @@ terraform_container() {
   done
   # Only start services which have been defined as startup services by composed
   # projects
-  local services=$(get_label_value "$container_name" "startup_services") 
+  local services="$(get_label_value $container_name startup_services)"
   compose_args+=("up" "-d" "$services")
 
   # Purge all existing containers within Dock environment
@@ -822,8 +821,8 @@ initialize_variables() {
   detach=false
   detach_keys="ctrl-x,x" # Ctrl-P is a useful shortcut when using Bash
   dock_in_dock=false # Don't create recursive Dock containers by default
-  pull=false
-  privileged=false
+  pull=true
+  privileged=true
   env=()
   optional_env=()
   required_env=()

--- a/test/configuration/privileged.bats
+++ b/test/configuration/privileged.bats
@@ -25,11 +25,11 @@ EOF
 
   run dock echo
   [ "$status" -eq 0 ]
-  [ ! -e is_privileged ]
-  [ -e is_not_privileged ]
+  [ -e is_privileged ]
+  [ ! -e is_not_privileged ]
 }
 
-@test "when privileged not specified container is not given privileges" {
+@test "when privileged not specified container is given privileges" {
   file .dock <<-EOF
 image alpine:latest
 detach true
@@ -39,7 +39,7 @@ EOF
   run docker inspect --format {{.HostConfig.Privileged}} my-project-dock
   docker stop my-project-dock || true
   [ "$status" -eq 0 ]
-  [ "$output" = false ]
+  [ "$output" = true ]
 }
 
 @test "when privileged set to false container is not given privileges" {


### PR DESCRIPTION
Dock is based on supporting launching docker containers
within a docker container to provide isolated development
environments so it makes sense that the privileged flag is
set to true by default (see https://blog.docker.com/2013/09/docker-can-now-run-within-docker/)
rather than false and forcing all client projects to explicitly
set it true.

It also seems to make sense to default the pull_latest flag to
true since operating against latest is generally a good and basic
tenet of proper dev/test practices and should be set to false explicitly
for specific/atypical use-cases.