### PR TITLE
Set project dock repo root to current working directory

### DIFF
--- a/bin/dock
+++ b/bin/dock
@@ -854,7 +854,7 @@ initialize_variables() {
     return 1
   fi
 
-  repo_root=$(git rev-parse --show-toplevel)
+  repo_root=$(pwd)
   repo=$(basename "$repo_root")
   repo=${repo//[^a-zA-Z0-9.-]/-} # Ensure slug is a valid name for Docker
   build_args=("docker" "build")


### PR DESCRIPTION
It should be safe to assume that dock can operate whereever it
is executed as long as the current directory meets the general
configuration requirements (i.e. is a part of a git repository
and contains a .dock file - for at least specifying how the Dock
development container is constructed).

So, rather than default a project's repo root to the top level
git repository root, default to the current working directory and trust
that it and the user adhere to the previously mentioned requirements.