### PR TITLE
Modify silencing command of project default commands during extension

### DIFF
--- a/bin/dock
+++ b/bin/dock
@@ -539,7 +539,9 @@ extend_container() {
 
   # Silence default_commands specified by projects during extension due to unexpected
   # behavior stemming from operating on an intermediary environment state
-  default_command sh
+  # TODO: Repurpose default_command with something more constructive (e.g. setting up
+  # a virtual dev environment for the project involved in the extension).
+  default_command tail -f /dev/null
 
   # add Dock environment construction labels
   label "dock.${project}" "$(pwd)/.dock"


### PR DESCRIPTION
Previously, the dock extension default command silencing mechanism was
to start a shell session (i.e. default_command sh). This is both somewhat
unnecessarily resource costly and also error prone since the ramifications
of relaunching a shell session in a different context but same session can
vary and at the very least could result in the container's entrypoint cmd
(process 1), set from previous extensions, exiting and causing the container
to exit/stop.

This change replaces sh with 'tail -f /dev/null' which has very little overhead
and, for all intensive purposes, works in keeping a dock container running during
extensions.

Also worth noting is that we intend to repurpose default_commands during extension
rather than silencing them in the near future.