### PR TITLE
Fix port_taken_on_localhost method for OSX machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Dock Change Log
 
+## master (unreleased)
+
+* Fix port_taken_on_localhost method for OSX machines
+
 ## 1.4.6 (2017-05-11)
 
 * Update README with startup_services configuration allowing users to specify

--- a/bin/dock
+++ b/bin/dock
@@ -774,7 +774,7 @@ destroy_container() {
 port_taken_on_localhost() {
   if osx; then
     # show -a(ll sockets) and -n(umeric addresses)
-    echo | netstat -a -n 2>/dev/null | grep $1 >/dev/null 2>&1
+    echo | lsof -n -i :$1 2>/dev/null | grep -i LISTEN >/dev/null 2>&1
   else
     echo | netstat --numeric --listening 2>/dev/null | grep $1 >/dev/null 2>&1
   fi


### PR DESCRIPTION
The netstat command that was used previously was not specifically
looking at LISTENING ports and was hitting false positives when there
was an open connection to a remote mysql instance as well as when you
had a port of like 409200 open it would fail the check for publishing
port 9200 (used by elasticsearch).

This lsof check will only show ports that are open and listening and
is explicit to the port being checked.