### PR TITLE
Adding WORKSPACE_DIR as enviroment variable

### DIFF
--- a/bin/dock
+++ b/bin/dock
@@ -578,10 +578,6 @@ extend_container() {
     exec "${command_args[@]}"
   fi
 
-  # Adding workspace directory as an enviroment variable. Since extending actually mounts the
-  # host file system path it needs to be set explicitly and not be set as the default /workdir
-  workspace_dir=$PWD
-
   # Compile run args based on current configuration
   compile_run_args
 
@@ -1037,7 +1033,13 @@ compile_run_args() {
     run_args+=("--env" "INSIDE_DOCK=1")
   fi
 
-  run_args+=("--env" "WORKSPACE_DIR=${workspace_dir}")
+  # For the extension and terraform we need to go up one directory since the workdir get's
+  # set to the last project that was terraformed.
+  if [ $workspace_dir != '/workspace' ]; then
+    run_args+=("--env" "WORKSPACE_DIR=${workspace_dir}/../")
+  else
+    run_args+=("--env" "WORKSPACE_DIR=${workspace_dir}")
+  fi
 
   process_exposed_ports
   if [ ${#published_ports[@]} -gt 0 ]; then


### PR DESCRIPTION
Adding in the WORKSPACE_DIR as an environment variable. The default
for standalone dock is /workspace where as when extending a project
the host file system path get's mounted. This will facilitate tooling.