### PR TITLE
Fix attachment flow when running `dock` with active project container

### DIFF
--- a/bin/dock
+++ b/bin/dock
@@ -967,7 +967,7 @@ check_for_existing_container() {
       if interactive; then
         ask "Attach to the container? (y/n)" n answer
         if [ "${answer}" = "y" ]; then
-          attach_to_container "target_container"
+          attach_to_container "$target_container"
         else
           info "You answered '${answer}' instead of 'y'; not attaching."
         fi
@@ -1153,6 +1153,7 @@ if [ $# -ge $OPTIND ]; then
   # Set command to remaining unparsed arguments
   # (overrides anything that was defined in $dock_file)
   command_args=("${@:$OPTIND}")
+  attach_command "${@:$OPTIND}"
 fi
 
 # If we're already inside a Dock environment, just execute the command.


### PR DESCRIPTION
This changes fixes a bug in the container attachment logic, resulting
from a missed env var expansion, which prevents users from reattaching to
Dock containers when executing `dock` in a project repo with the
associated Dock container already up and running. The bug was introduced
in change:
https://github.com/brigade/dock/commit/01e5fd92a7f02b62fdf16674bd75135c63bf60b3#diff-79d7079a017e90205ccbbe385c9ce6a8R805

Also, while at it, updated the attachment logic to allow users to specify
additional command line args to be executed immediately following Dock
container attachment.

e.g.:
-----
- running `dock bash` and choosing to attach to a container results in the
  creation of and entry to a bash shell rather than the default 'sh'
  shell
- running `dock ls` and choosing to attach to a container results in the
  listing of the current working directory upon entry followed by exiting
  of the container